### PR TITLE
Feat/5 2.1-3 ID 전략 통합

### DIFF
--- a/src/main/java/IdGenerator.java
+++ b/src/main/java/IdGenerator.java
@@ -1,0 +1,34 @@
+import java.time.Instant;
+
+public class IdGenerator {
+    private final TimestampBasedIdGenerator timestampBasedIdGenerator;
+    private final ShardIdGenerator shardIdGenerator;
+    private final SequenceIdGenerator sequenceIdGenerator;
+
+    public IdGenerator(
+            final TimestampBasedIdGenerator timestampBasedIdGenerator,
+            final ShardIdGenerator shardIdGenerator,
+            final SequenceIdGenerator sequenceIdGenerator
+    ) {
+        this.timestampBasedIdGenerator = timestampBasedIdGenerator;
+        this.shardIdGenerator = shardIdGenerator;
+        this.sequenceIdGenerator = sequenceIdGenerator;
+    }
+
+    public long generate(final Instant timestamp) {
+        final var timestampId = timestampBasedIdGenerator.generate(timestamp);
+        final var shardId = shardIdGenerator.generate();
+        final var sequenceId = sequenceIdGenerator.generate(timestamp.toEpochMilli(), shardId - 1);
+        return combine(timestampId, shardId, sequenceId);
+    }
+
+    private long combine(final long timestampId, final long shardId, final long sequenceId) {
+        final var allocatedShardIdBits = shardIdGenerator.allocatedBits();
+        final var allocatedSequenceIdBits = sequenceIdGenerator.allocatedBits();
+
+        var id = timestampId << (allocatedShardIdBits + allocatedSequenceIdBits);
+        id |= shardId << allocatedSequenceIdBits;
+        id |= sequenceId;
+        return id;
+    }
+}

--- a/src/main/java/SequenceByShardIdentifierGroup.java
+++ b/src/main/java/SequenceByShardIdentifierGroup.java
@@ -2,23 +2,23 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 
 public record SequenceByShardIdentifierGroup(
-        Map<Integer, SequenceByTimestamp> value
+        Map<Long, SequenceByTimestamp> value
 ) {
     private static final long SEQUENCE_INITIALIZE = 0L;
     private static final long TIMESTAMP_INITIALIZE = -1L;
 
-    public static SequenceByShardIdentifierGroup from(final int instanceIdentifierCount) {
+    public static SequenceByShardIdentifierGroup from(final long instanceIdentifierCount) {
         return new SequenceByShardIdentifierGroup(
                 sequenceByShardIdentifierGroupValue(instanceIdentifierCount)
         );
     }
 
-    private static ConcurrentHashMap<Integer, SequenceByTimestamp> sequenceByShardIdentifierGroupValue(
-            final int instanceIdentifierCount) {
-        return IntStream.range(0, instanceIdentifierCount)
+    private static ConcurrentHashMap<Long, SequenceByTimestamp> sequenceByShardIdentifierGroupValue(
+            final long instanceIdentifierCount) {
+        return LongStream.range(0, instanceIdentifierCount)
                 .boxed()
                 .collect(Collectors.toMap(
                         i -> i,
@@ -28,7 +28,7 @@ public record SequenceByShardIdentifierGroup(
                 ));
     }
 
-    public long sequence(final long timestamp, int instanceIdentifier) {
+    public long sequence(final long timestamp, long instanceIdentifier) {
         if (!value.containsKey(instanceIdentifier)) {
             throw new IllegalArgumentException("인스턴스 식별자가 포함되어 있지 않습니다.");
         }

--- a/src/main/java/SequenceIdGenerator.java
+++ b/src/main/java/SequenceIdGenerator.java
@@ -15,13 +15,17 @@ public class SequenceIdGenerator {
         );
     }
 
+    public long allocatedBits() {
+        return SEQUENCE_BITS;
+    }
+
     private static void verifyInstanceIdentifierCount(int instanceIdentifierCount) {
         if (instanceIdentifierCount < 0 || instanceIdentifierCount > MAX_SEQUENCE) {
             throw new IllegalArgumentException("인스턴스 식별자는 10비트 이내이어야 한다");
         }
     }
 
-    public long generate(final long timestamp, final int shardInstanceIdentifier) {
+    public long generate(final long timestamp, final long shardInstanceIdentifier) {
         return sequenceGroup.sequence(timestamp, shardInstanceIdentifier);
     }
 }

--- a/src/main/java/ShardIdGenerator.java
+++ b/src/main/java/ShardIdGenerator.java
@@ -17,6 +17,10 @@ public final class ShardIdGenerator {
         return instanceIdentifier;
     }
 
+    public long allocatedBits() {
+        return SHARD_ID_BITS;
+    }
+
     private static void verifyShardIdRange(final int shardId) {
         if (shardId < 0 || shardId > MAX_SHARD_ID) {
             final var errorMessage = """

--- a/src/test/java/IdGeneratorTest.java
+++ b/src/test/java/IdGeneratorTest.java
@@ -1,0 +1,30 @@
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class IdGeneratorTest {
+    @Test
+    @DisplayName("아이디 생성")
+    void id_generator() {
+        final var timestampBasedIdGenerator = TimestampBasedIdGenerator.referenceDateTime(LocalDateTime.of(2025, 1, 1, 0, 0, 0));
+        final var shardIdGenerator = ShardIdGenerator.from(1);
+        final var sequenceIdGenerator = SequenceIdGenerator.from(1);
+        final var timestamp = instant(LocalDateTime.of(2025, 2, 1, 0, 0, 0));
+
+        final var sut = new IdGenerator(timestampBasedIdGenerator,  shardIdGenerator, sequenceIdGenerator);
+
+        assertThat(sut.generate(timestamp)).isEqualTo(22468047667201025L);
+    }
+
+    private Instant instant(LocalDateTime localDateTime) {
+        return localDateTime.atZone(ZoneOffset.UTC).toInstant();
+    }
+}


### PR DESCRIPTION
# 2.1-3 ID 전략 통합

# 작업 내용

## 타임 스탬프 41비트
- 타입스탬프 ID 전략, 샤드 ID 생성 전략, 스퀀스 ID 생성 전략을 통합하여 하나의 64 비트인 long 타입의 ID 생성

# 추후 고려 사항
- 각 ID 생성 전략마다 할당된 비트를 외부에서 주입받으면 유연한 D 생성 가능할 듯. ID 전략 통합 객체가 각 ID 생성 전략에 할당될 비트 관리 책임 수행.


Close #5 
